### PR TITLE
Remove OPA from html

### DIFF
--- a/gel_cover_report_template.html
+++ b/gel_cover_report_template.html
@@ -106,7 +106,7 @@
 			</tr>
 			<tr>
 				<td style="text-align: left;">Interpretation Request ID:</td>
-				<td style="text-align: centre;">OPA{{IRID}}</td>
+				<td style="text-align: centre;">{{IRID}}</td>
 			</tr>
 		</table>
 	</div>


### PR DESCRIPTION
Some cases are now going through Sapientia so OPA is incorrect.
Discussed with @woook and we agreed that we will stop putting the cip prefix on the IR ID

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/moka-guys/gel_reports/21)
<!-- Reviewable:end -->
